### PR TITLE
Persist username across launches using UserDefaults

### DIFF
--- a/LeetBar/ViewModels/ViewModel.swift
+++ b/LeetBar/ViewModels/ViewModel.swift
@@ -41,7 +41,11 @@ final class ViewModel: ObservableObject {
     @Published var allSolved: Int = 0
     @Published var allTotal: Int = 0
     
-    @Published var username: String = ""
+    @Published var username: String = "" {
+        didSet {
+            UserDefaults.standard.set(username, forKey: "username")
+        }
+    }
     @Published var isValidUsername: Bool = true
     
     @Published var showLoading: Bool = true
@@ -63,6 +67,7 @@ final class ViewModel: ObservableObject {
 
     init(service: HTTPLeetService = LeetService()) {
         self.service = service
+        username = UserDefaults.standard.string(forKey: "username") ?? ""
     }
     
     func fetchUserData(refreshEvent: RefreshEvent) async throws {

--- a/LeetBar/ViewModels/ViewModel.swift
+++ b/LeetBar/ViewModels/ViewModel.swift
@@ -67,7 +67,7 @@ final class ViewModel: ObservableObject {
 
     init(service: HTTPLeetService = LeetService()) {
         self.service = service
-        username = UserDefaults.standard.string(forKey: "username") ?? ""
+        self.username = UserDefaults.standard.string(forKey: "username") ?? ""
     }
     
     func fetchUserData(refreshEvent: RefreshEvent) async throws {

--- a/LeetBar/ViewModels/ViewModel.swift
+++ b/LeetBar/ViewModels/ViewModel.swift
@@ -41,7 +41,7 @@ final class ViewModel: ObservableObject {
     @Published var allSolved: Int = 0
     @Published var allTotal: Int = 0
     
-    @Published var username: String = "" {
+    @Published var username: String {
         didSet {
             UserDefaults.standard.set(username, forKey: "username")
         }

--- a/LeetBarTests/LeetBarTests.swift
+++ b/LeetBarTests/LeetBarTests.swift
@@ -43,6 +43,15 @@ class LeetBarTests: XCTestCase {
         assertInitialization(viewModel: vm)
         
     }
+
+    func test_ViewModel_username_isPersisted() {
+        vm = ViewModel(service: MockLeetServiceNil())
+
+        vm.username = "TestUsername"
+        vm = ViewModel(service: MockLeetServiceNil())
+
+        XCTAssertEqual(vm.username, "TestUsername")
+    }
     
     func assertInitialization(viewModel: ViewModel) {
         XCTAssertEqual(vm.dailyProblemLink, "", "dailyProblemLink")


### PR DESCRIPTION
Hi!
First of all, I wanted to thank you for this project! It is nice to have a quick way of checking your LeetCode progress, and access the daily problem.
I have been using it for a while, and one thing that is a bit tedious, is that you need to enter the username each time you launch the app.

This PR aims to solve that by persisting the username using `UserDefaults`.

Let me know if these changes are OK, or if you have any comments.